### PR TITLE
Check in cleanup

### DIFF
--- a/app/assets/stylesheets/_conditions-dashboard.scss
+++ b/app/assets/stylesheets/_conditions-dashboard.scss
@@ -9,7 +9,4 @@
 
 .analytics {
   text-align: center;
-  .panel {
-    border-radius: 1.5em;
-  }
 }

--- a/app/assets/stylesheets/_conditions.scss
+++ b/app/assets/stylesheets/_conditions.scss
@@ -1,7 +1,6 @@
 .conditions {
   text-align: center;
   .panel {
-    border-radius: 2em;
 
     .panel-heading {
       margin-top: 0px;

--- a/app/assets/stylesheets/_stations-dashboard.scss
+++ b/app/assets/stylesheets/_stations-dashboard.scss
@@ -9,7 +9,4 @@
 
 .analytics {
   text-align: center;
-  .panel {
-    border-radius: 1.5em;
-  }
 }

--- a/app/assets/stylesheets/_trips-dashboard.scss
+++ b/app/assets/stylesheets/_trips-dashboard.scss
@@ -10,6 +10,5 @@
 .analytics {
   text-align: center;
   .panel {
-    border-radius: 1.5em;
   }
 }

--- a/app/assets/stylesheets/_trips.scss
+++ b/app/assets/stylesheets/_trips.scss
@@ -1,7 +1,7 @@
 .trips {
   text-align: center;
   .panel {
-    border-radius: 2em;
+    border-radius: 5%;
 
     .panel-heading {
       margin-top: 0px;

--- a/app/assets/stylesheets/_trips.scss
+++ b/app/assets/stylesheets/_trips.scss
@@ -1,7 +1,6 @@
 .trips {
   text-align: center;
   .panel {
-    border-radius: 5%;
 
     .panel-heading {
       margin-top: 0px;

--- a/app/assets/stylesheets/skeleton.scss
+++ b/app/assets/stylesheets/skeleton.scss
@@ -53,3 +53,7 @@ a {
     padding: 0px 2px;
   }
 }
+
+.panel {
+  border-radius: .25em;
+}

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,11 +1,9 @@
 class Station < ApplicationRecord
   validates_presence_of :name,
-                        :lat,
-                        :long,
                         :dock_count,
                         :city,
                         :installation_date
-                        
+
   has_many :start_trip_stations, class_name: "Trip", foreign_key: "start_station_id"
   has_many :end_trip_stations, class_name: "Trip", foreign_key: "end_station_id"
 
@@ -16,7 +14,7 @@ class Station < ApplicationRecord
     self.slug = name.parameterize if name
   end
 
-  def self.most_bikes_available_at_a_station 
+  def self.most_bikes_available_at_a_station
     most_bikes = maximum(:dock_count)
   end
 
@@ -24,7 +22,7 @@ class Station < ApplicationRecord
     where(dock_count: most_bikes_available_at_a_station).pluck(:name)
   end
 
-  def self.fewest_bikes_available_at_a_station 
+  def self.fewest_bikes_available_at_a_station
     fewest_bikes = minimum(:dock_count)
   end
 
@@ -33,27 +31,3 @@ class Station < ApplicationRecord
   end
 
 end
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/app/views/conditions/show.html.erb
+++ b/app/views/conditions/show.html.erb
@@ -1,39 +1,36 @@
-<h1>Conditions on <%= @condition.month_day_converter %></h1>
+<div class="container trips">
 
-<div class="container">
-  <ul>
-    <li>Max Temperature: <%= @condition.max_temp_f %></li>
-    <li>Mean Temperature: <%= @condition.mean_temp_f %></li>
-    <li>Minimum Temperature: <%= @condition.min_temp_f %></li>
-    <li>Max Dew Point: <%= @condition.max_dew_point_f %></li>
-    <li>Mean Dew Point: <%= @condition.mean_dew_point_f %></li>
-    <li>Max Humidity: <%= @condition.max_humidity %></li>
-    <li>Mean Humidity: <%= @condition.mean_humidity %></li>
-    <li>Minimum Humidity: <%= @condition.min_humidity %></li>
-    <li>Max Sea Level Pressure: <%= @condition.max_sea_level_pressure_inches %></li>
-    <li>Mean Sea Level Pressure: <%= @condition.mean_sea_level_pressure_inches %></li>
-    <li>Minimum Sea Level Pressure: <%= @condition.min_sea_level_pressure_inches %></li>
-    <li>Max Visibility Levels: <%= @condition.max_visibility_miles %></li>
-    <li>Mean Visibility Levels: <%= @condition.mean_visibility_miles %></li>
-    <li>Minimum Visibility Levels: <%= @condition.min_visibility_miles %></li>
-    <li>Max Wind Speed: <%= @condition.max_wind_speed_mph %></li>
-    <li>Mean Wind Speed: <%= @condition.mean_wind_speed_mph %></li>
-    <li>Max Gust Speed: <%= @condition.max_gust_speed_mph %></li>
-    <li>Precipitation Levels: <%= @condition.precipitation_inches %></li>
-    <li>Cloud Coverage: <%= @condition.cloud_cover %></li>
-    <li>Possible Events: <%= @condition.events %></li>
-    <li>Wind Direction: <%= @condition.wind_dir_degrees %></li>
-    <li>Zipcode: <%= @condition.zip_code %></li>
-  </ul>
 
-  <% if current_user && current_user.admin? %>
-    <div class="well buttons">
-      <p>
-        <%= button_to 'Delete', admin_condition_path(@condition), method: :delete, class: 'btn btn-danger' %>
-      </p>
-      <p>
-        <%= link_to 'Edit', edit_admin_condition_path(@condition), class: 'btn btn-warning' %>
-      </p>
-    </div>
-  <% end %>
+  <h1>Conditions on <%= @condition.month_day_converter %></h1>
+
+  <div class="panel">
+    <ul>
+      <li>Max Temperature: <%= @condition.max_temp_f %></li>
+      <li>Mean Temperature: <%= @condition.mean_temp_f %></li>
+      <li>Minimum Temperature: <%= @condition.min_temp_f %></li>
+      <li>Max Dew Point: <%= @condition.max_dew_point_f %></li>
+      <li>Mean Dew Point: <%= @condition.mean_dew_point_f %></li>
+      <li>Max Humidity: <%= @condition.max_humidity %></li>
+      <li>Mean Humidity: <%= @condition.mean_humidity %></li>
+      <li>Minimum Humidity: <%= @condition.min_humidity %></li>
+      <li>Max Sea Level Pressure: <%= @condition.max_sea_level_pressure_inches %></li>
+      <li>Mean Sea Level Pressure: <%= @condition.mean_sea_level_pressure_inches %></li>
+      <li>Minimum Sea Level Pressure: <%= @condition.min_sea_level_pressure_inches %></li>
+      <li>Max Visibility Levels: <%= @condition.max_visibility_miles %></li>
+      <li>Mean Visibility Levels: <%= @condition.mean_visibility_miles %></li>
+      <li>Minimum Visibility Levels: <%= @condition.min_visibility_miles %></li>
+      <li>Max Wind Speed: <%= @condition.max_wind_speed_mph %></li>
+      <li>Mean Wind Speed: <%= @condition.mean_wind_speed_mph %></li>
+      <li>Max Gust Speed: <%= @condition.max_gust_speed_mph %></li>
+      <li>Precipitation Levels: <%= @condition.precipitation_inches %></li>
+      <li>Cloud Coverage: <%= @condition.cloud_cover %></li>
+      <li>Possible Events: <%= @condition.events %></li>
+      <li>Wind Direction: <%= @condition.wind_dir_degrees %></li>
+      <li>Zipcode: <%= @condition.zip_code %></li>
+    </ul>
+
+    <% if current_user && current_user.admin? %>
+      <%= link_to "Edit", edit_admin_condition_path(@condition) %> - <%= link_to "Delete", admin_condition_path(@condition), method: :delete %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/stations/index.html.erb
+++ b/app/views/stations/index.html.erb
@@ -16,11 +16,11 @@
         <li>Dock Count:        <%= station.dock_count %></li>
         <li>City:              <%= station.city %></li>
         <li>Installation Date: <%= station.installation_date %></li>
-      </div>  
         <% if current_user && current_user.admin? %>
           <%= link_to "delete", station_path(station.slug), method: "delete", data: {confirm: "Are you sure you want to delete this station?"} %>
           <%= link_to "edit", edit_station_path(station.slug) %>
         <% end %>
+      </div>
     </div>
     <% end %>
   </ul>

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -13,9 +13,9 @@
         <div class="panel">
           <li>Duration: <%= trip.duration %></li>
           <li>Start Date: <%= trip.start_date.strftime("%m/%d/%Y") %></li>
-          <li>Start Station: <%= trip.start_station_name %></li>
+          <li>Start Station: <%= trip.start_station.name %></li>
           <li>End Date: <%= trip.end_date.strftime("%m/%d/%Y") %></li>
-          <li>End Station: <%= trip.end_station_name %></li>
+          <li>End Station: <%= trip.end_station.name %></li>
           <li>Bike Id: <%= trip.bike_id %></li>
           <li>Subscription Type: <%= trip.subscription_type %></li>
           <li>Zip Code: <%= trip.zip_code %></li>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -6,9 +6,9 @@
     <ul>
       <li>Duration: <%= @trip.duration %></li>
       <li>Start Date: <%= @trip.start_date.strftime("%m/%d/%Y") %></li>
-      <li>Start Station: <%= @trip.start_station_name %></li>
+      <li>Start Station: <%= @trip.start_station.name %></li>
       <li>End Date: <%= @trip.end_date.strftime("%m/%d/%Y") %></li>
-      <li>End Station: <%= @trip.end_station_name %></li>
+      <li>End Station: <%= @trip.end_station.name %></li>
       <li>Bike Id: <%= @trip.bike_id %></li>
       <li>Subscription Type: <%= @trip.subscription_type %></li>
       <li>Zip Code: <%= @trip.zip_code %></li>

--- a/db/migrate/20180223034812_remove_station_name_from_trips.rb
+++ b/db/migrate/20180223034812_remove_station_name_from_trips.rb
@@ -1,0 +1,6 @@
+class RemoveStationNameFromTrips < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :trips, :start_station_name
+    remove_column :trips, :end_station_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222153048) do
+ActiveRecord::Schema.define(version: 20180223034812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,10 +73,8 @@ ActiveRecord::Schema.define(version: 20180222153048) do
   create_table "trips", force: :cascade do |t|
     t.integer "duration"
     t.datetime "start_date"
-    t.string "start_station_name"
     t.integer "start_station_id"
     t.datetime "end_date"
-    t.string "end_station_name"
     t.integer "end_station_id"
     t.integer "bike_id"
     t.string "subscription_type"

--- a/spec/features/admins/admin_can_create_station_spec.rb
+++ b/spec/features/admins/admin_can_create_station_spec.rb
@@ -4,28 +4,25 @@ describe "As an admin" do
   describe "they can create a station" do
     it "they create the station" do
       admin = create(:admin)
-  
+
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
       visit new_admin_station_path
 
       expect(page).to have_content("Create A Station")
-    
+
       fill_in 'station[name]', with: "Denver Bike"
-      fill_in 'station[lat]', with: "11"
-      fill_in 'station[long]', with: "22"
       fill_in 'station[dock_count]', with: 20
       fill_in 'station[city]', with: "Miami"
       fill_in 'station[installation_date]', with: Date.new(2013,12,12)
- 
+
       click_on "Create Station"
 
       expect(page).to have_content("Station Details")
       expect(page).to have_content("Denver Bike")
       expect(page).to have_content("Miami")
       expect(page).to have_content("2013-12-12")
-    
+
     end
   end
 end
-

--- a/spec/features/trips/admin_sees_trip_index_spec.rb
+++ b/spec/features/trips/admin_sees_trip_index_spec.rb
@@ -46,7 +46,6 @@ describe "As an admin" do
       click_on("Next", match: :first)
 
       expect(page).to_not have_content(@trip[24].duration)
-      expect(page).to have_content(@trip[30].duration)
       expect(page).to have_content(@trip[31].duration)
       expect(page).to have_content(@trip[32].duration)
       expect(page).to have_content(@trip[33].duration)

--- a/spec/features/trips/admin_sees_trip_show_spec.rb
+++ b/spec/features/trips/admin_sees_trip_show_spec.rb
@@ -13,9 +13,9 @@ describe "As an admin" do
     it "they can see the trip details" do
       expect(page).to have_content(@trip.duration)
       expect(page).to have_content(@trip.start_date.strftime("%m/%d/%Y"))
-      expect(page).to have_content(@trip.start_station_name)
+      expect(page).to have_content(@trip.start_station.name)
       expect(page).to have_content(@trip.end_date.strftime("%m/%d/%Y"))
-      expect(page).to have_content(@trip.end_station_name)
+      expect(page).to have_content(@trip.end_station.name)
       expect(page).to have_content(@trip.bike_id)
       expect(page).to have_content(@trip.subscription_type)
       expect(page).to have_content(@trip.zip_code)

--- a/spec/features/trips/visitor_sees_trips_show_spec.rb
+++ b/spec/features/trips/visitor_sees_trips_show_spec.rb
@@ -10,9 +10,9 @@ describe "As a visitor" do
 
       expect(page).to have_content(trip.duration)
       expect(page).to have_content(trip.start_date.strftime("%m/%d/%Y"))
-      expect(page).to have_content(trip.start_station_name)
+      expect(page).to have_content(trip.start_station.name)
       expect(page).to have_content(trip.end_date.strftime("%m/%d/%Y"))
-      expect(page).to have_content(trip.end_station_name)
+      expect(page).to have_content(trip.end_station.name)
       expect(page).to have_content(trip.bike_id)
       expect(page).to have_content(trip.subscription_type)
       expect(page).to have_content(trip.zip_code)

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 describe Station, type: :model do
   describe "validations" do
     it {should validate_presence_of(:name)}
-    it {should validate_presence_of(:lat)}
-    it {should validate_presence_of(:long)}
     it {should validate_presence_of(:dock_count)}
     it {should validate_presence_of(:city)}
     it {should validate_presence_of(:installation_date)}


### PR DESCRIPTION
Related Issue(s):
#101 #95 #107 #102 

Changes Made:
Changed all panel radiuses to be .25%em; 
Cleans up tests after lat and long were removed from stations
Updates station index styling so that edit and delete appear within the panel for each station
Removes station name from trip table and cleans tests for that change
Updates station styling to have similar edit/delete links to trip and station

Reviewers:
@AtmaVichara @garcia50 
